### PR TITLE
chore: up ci for dogfooding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
             experimental/relay-direct-rtc,
             experimental/rln-js,
             experimental/rln-identity,
+            dogfooding,
             flush-notes
           ]
     runs-on: ubuntu-latest

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
         stage('experimental/relay-direct-rtc') { steps { script { buildExample() } } }
         stage('experimental/rln-js') { steps { script { buildExample() } } }
         stage('experimental/rln-identity') { steps { script { buildExample() } } }
+        stage('dogfooding') { steps { script { buildExample() } } }
         stage('flush-notes') { steps { script { buildExample() } } }
       }
     }


### PR DESCRIPTION
Follow up to https://github.com/waku-org/lab.waku.org/pull/68

Adds `dogfooding` app to CI