### PR TITLE
chore: up nodejs

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.16
+FROM node:18-alpine3.20
 
 LABEL maintainer="jakub@status.im"
 


### PR DESCRIPTION
## Problem

Due to following error:
```
unhandledRejection ReferenceError: Headers is not defined
    at Object.<anonymous> (/home/jenkins/workspace/website/lab.waku.org/examples/flush-notes/node_modules/next/dist/server/web/spec-extension/adapters/headers.js:32:30)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)
    at Module.require (node:internal/modules/cjs/loader:1098:19)
    at Module.mod.require (/home/jenkins/workspace/website/lab.waku.org/examples/flush-notes/node_modules/next/dist/server/require-hook.js:64:28)
    at require (node:internal/modules/cjs/helpers:108:18)
    at Object.<anonymous> (/home/jenkins/workspace/website/lab.waku.org/examples/flush-notes/node_modules/next/dist/server/api-utils/index.js:63:18)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
```

It seems that `NextJS` cannot work in Jenkins due to low version of NodeJS.

## Solution

Update NodeJS version 

## Notes

One of the fixes for https://github.com/waku-org/lab.waku.org/issues/74