### PR TITLE
chore: make dogfooding run in production

### DIFF
--- a/examples/dogfooding/package.json
+++ b/examples/dogfooding/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "build": "webpack --config webpack.config.js",
+    "build": "webpack --config webpack.config.js --mode production",
     "start": "webpack-dev-server"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

Due to development mode being used for dogfooding app - it fails to run from the domain.
![image](https://github.com/user-attachments/assets/9f9821ab-20aa-4abc-bdd1-08963c5124c7)

## Solution

Use production mode for deployment. 