### PR TITLE
chore: update dogfooding app to latest

### DIFF
--- a/examples/dogfooding/package-lock.json
+++ b/examples/dogfooding/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@libp2p/peer-id": "^4.1.2",
-        "@waku/sdk": "0.0.27-c33844e.0",
+        "@waku/sdk": "0.0.27-39f8920.0",
         "protobufjs": "^7.3.0"
       },
       "devDependencies": {
@@ -1220,15 +1220,15 @@
       "dev": true
     },
     "node_modules/@waku/core": {
-      "version": "0.0.31-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.31-c33844e.0.tgz",
-      "integrity": "sha512-L0UyMsxn8KC0sT3J5lDxlVHZBEct/e0ykrrK/ohhP1IvCeYlCdHjDp3yQgzm3E/Gq+1NAMiDh+Qa2RvaS7e2bw==",
+      "version": "0.0.31-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.31-39f8920.0.tgz",
+      "integrity": "sha512-FtfoXEFSFSEMXZTcTSTNO+FaAuNvUQGH0EQctLUhnTIZN7vqg6MGDDZv4GgPoLhoME5Af6TorTmhq3TPiKVkgg==",
       "dependencies": {
         "@libp2p/ping": "^1.1.2",
-        "@waku/enr": "0.0.25-c33844e.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/proto": "0.0.8-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0",
+        "@waku/enr": "0.0.25-39f8920.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/proto": "0.0.8-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0",
         "debug": "^4.3.4",
         "it-all": "^3.0.4",
         "it-length-prefixed": "^9.0.4",
@@ -1242,10 +1242,10 @@
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
-        "@waku/enr": "0.0.25-c33844e.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/proto": "0.0.8-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0",
+        "@waku/enr": "0.0.25-39f8920.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/proto": "0.0.8-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0",
         "libp2p": "^1.8.1"
       },
       "peerDependenciesMeta": {
@@ -1258,15 +1258,15 @@
       }
     },
     "node_modules/@waku/discovery": {
-      "version": "0.0.4-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/discovery/-/discovery-0.0.4-c33844e.0.tgz",
-      "integrity": "sha512-Zy2pDwhdy8RhhjfCYCvKj0xMnH/fu02T8d8qMIY8TYjhobg3+xMdWrGjNQQLF26+1eKHdYVft7F0aULVqYrx+Q==",
+      "version": "0.0.4-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/discovery/-/discovery-0.0.4-39f8920.0.tgz",
+      "integrity": "sha512-KQme0V+8syqpQYvBO62Iny1yiwBhFSV2l9/O7vmyiyOQ+ULsfY9mpVv6ua2+L4Swl6YeKlVTIWsYhRgTzJwuyA==",
       "dependencies": {
-        "@waku/core": "0.0.31-c33844e.0",
-        "@waku/enr": "0.0.25-c33844e.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/proto": "0.0.8-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0",
+        "@waku/core": "0.0.31-39f8920.0",
+        "@waku/enr": "0.0.25-39f8920.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/proto": "0.0.8-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0",
         "debug": "^4.3.4",
         "dns-query": "^0.11.2",
         "hi-base32": "^0.5.1",
@@ -1277,11 +1277,11 @@
       },
       "peerDependencies": {
         "@libp2p/interface": "^1.6.3",
-        "@waku/core": "0.0.31-c33844e.0",
-        "@waku/enr": "0.0.25-c33844e.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/proto": "0.0.8-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0"
+        "@waku/core": "0.0.31-39f8920.0",
+        "@waku/enr": "0.0.25-39f8920.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/proto": "0.0.8-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0"
       },
       "peerDependenciesMeta": {
         "@libp2p/interface": {
@@ -1293,16 +1293,16 @@
       }
     },
     "node_modules/@waku/enr": {
-      "version": "0.0.25-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.25-c33844e.0.tgz",
-      "integrity": "sha512-e5z0yCmI+clxO4V3nkNE5dTnswF4UIjQXpWMChr/54ExrJ2dFOHSZfs3jgDa3ZXt23rKa0AuHFJAxYOhModvQA==",
+      "version": "0.0.25-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.25-39f8920.0.tgz",
+      "integrity": "sha512-aqSUTOaESKp0Fzc4h3Pukwl0KVm4eMlgB2yV/9jdAQhGjchVdqSWd0Ll3fmv89Gk/yy3NKisHS4KQeVezDWRBw==",
       "dependencies": {
         "@ethersproject/rlp": "^5.7.0",
         "@libp2p/crypto": "^4.1.6",
         "@libp2p/peer-id": "^4.2.1",
         "@multiformats/multiaddr": "^12.0.0",
         "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.19-c33844e.0",
+        "@waku/utils": "0.0.19-39f8920.0",
         "debug": "^4.3.4",
         "js-sha3": "^0.9.2"
       },
@@ -1311,8 +1311,8 @@
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0"
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0"
       },
       "peerDependenciesMeta": {
         "@multiformats/multiaddr": {
@@ -1324,31 +1324,31 @@
       }
     },
     "node_modules/@waku/interfaces": {
-      "version": "0.0.26-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.26-c33844e.0.tgz",
-      "integrity": "sha512-hsSXaqXKbd/fdnDE1sRiw8XYPDekNfkFFo0Glxe6tAsndwZfjLnQabejTQmAPCQouNEU5LK8B5u1y6MwQoM36w==",
+      "version": "0.0.26-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.26-39f8920.0.tgz",
+      "integrity": "sha512-1PQtPYGWqW26M1InbraBVRPXJaMxq7daBjwaMW0xTkAETl59alI0MsjizAaZsL+CklWprD0pnZGs7nm7wOixPA==",
       "dependencies": {
-        "@waku/proto": "0.0.8-c33844e.0"
+        "@waku/proto": "0.0.8-39f8920.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@waku/message-hash": {
-      "version": "0.1.15-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/message-hash/-/message-hash-0.1.15-c33844e.0.tgz",
-      "integrity": "sha512-PVjXm2tv90IO66sLPM0iJ+eav4foQPDpZ/nurqixwmWBRocq4ydQKlj3D7y7epJY5uC6mgQ63282Br2oVaim5A==",
+      "version": "0.1.15-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/message-hash/-/message-hash-0.1.15-39f8920.0.tgz",
+      "integrity": "sha512-sLCSU2p23Wx2YktQjTDlJezTQjKArnK1+q+OYifJ57MmkX25/v87hjSUtC1Dn30VV35d7itabUvyN4W7oqwysA==",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/utils": "0.0.19-c33844e.0"
+        "@waku/utils": "0.0.19-39f8920.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0"
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0"
       },
       "peerDependenciesMeta": {
         "@waku/interfaces": {
@@ -1357,9 +1357,9 @@
       }
     },
     "node_modules/@waku/proto": {
-      "version": "0.0.8-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.8-c33844e.0.tgz",
-      "integrity": "sha512-k2KkeVQB8yq163p1yXMLPwEISv9JiMeouxg02QiOJJnnKVuSl240b6cJ3HhCeVSfSH0TNNu616qwzdQUpL2xcA==",
+      "version": "0.0.8-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.8-39f8920.0.tgz",
+      "integrity": "sha512-Sia5NhbpYKdjBweZnuzpD9IfYy5hsvTBM5mCUHrTn4NgwBHDQQFVug6KWRKJJkNtAa22zWM39g9OpbxSuBTd7g==",
       "dependencies": {
         "protons-runtime": "^5.4.0"
       },
@@ -1368,16 +1368,16 @@
       }
     },
     "node_modules/@waku/relay": {
-      "version": "0.0.14-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.14-c33844e.0.tgz",
-      "integrity": "sha512-JY5o9b+OPS+kHQdThrNn3U6/dwcBS9o6XrOLixtYiIo9kZyj0VnXyuEnxaCd0veMqZW0Netc07HhvDHHCr/5pQ==",
+      "version": "0.0.14-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.14-39f8920.0.tgz",
+      "integrity": "sha512-6EcD832E2n4+tMy1GhhsUawWnbExVDsmZndXO6tcnDMR75WBE/FglMOsG2x+L39tEatftmKgGfDQZ4aIkr8Z5w==",
       "dependencies": {
         "@chainsafe/libp2p-gossipsub": "^13.1.0",
         "@noble/hashes": "^1.3.2",
-        "@waku/core": "0.0.31-c33844e.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/proto": "0.0.8-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0",
+        "@waku/core": "0.0.31-39f8920.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/proto": "0.0.8-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
         "fast-check": "^3.19.0"
@@ -1387,10 +1387,10 @@
       },
       "peerDependencies": {
         "@chainsafe/libp2p-gossipsub": "^12.0.0",
-        "@waku/core": "0.0.31-c33844e.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/proto": "0.0.8-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0"
+        "@waku/core": "0.0.31-39f8920.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/proto": "0.0.8-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0"
       },
       "peerDependenciesMeta": {
         "@chainsafe/libp2p-gossipsub": {
@@ -1402,9 +1402,9 @@
       }
     },
     "node_modules/@waku/sdk": {
-      "version": "0.0.27-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.27-c33844e.0.tgz",
-      "integrity": "sha512-GZ6hKw5d+C6O6q92sgcMMKSE97ejEE6F9MfaKWIKsVBkSRBEe18c4pd/w6JPmDZZ9CEqHwMpShuDUq3qGcUb2w==",
+      "version": "0.0.27-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.27-39f8920.0.tgz",
+      "integrity": "sha512-N4b+Rh0bNatmUhKp7uPtab2uCJ6v22nmiacWWebSDjfWl8p2PZ2ZUkLxoF+mANTbkgMRdWVEmMDv5WOD2ltdAg==",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^15.1.0",
         "@libp2p/bootstrap": "^10.1.2",
@@ -1413,12 +1413,12 @@
         "@libp2p/ping": "^1.1.2",
         "@libp2p/websockets": "^8.1.4",
         "@noble/hashes": "^1.3.3",
-        "@waku/core": "0.0.31-c33844e.0",
-        "@waku/discovery": "0.0.4-c33844e.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/proto": "0.0.8-c33844e.0",
-        "@waku/relay": "0.0.14-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0",
+        "@waku/core": "0.0.31-39f8920.0",
+        "@waku/discovery": "0.0.4-39f8920.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/proto": "0.0.8-39f8920.0",
+        "@waku/relay": "0.0.14-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0",
         "libp2p": "^1.8.1"
       },
       "engines": {
@@ -1426,11 +1426,11 @@
       },
       "peerDependencies": {
         "@libp2p/bootstrap": "^10",
-        "@waku/core": "0.0.31-c33844e.0",
-        "@waku/interfaces": "0.0.26-c33844e.0",
-        "@waku/message-hash": "0.1.15-c33844e.0",
-        "@waku/relay": "0.0.14-c33844e.0",
-        "@waku/utils": "0.0.19-c33844e.0"
+        "@waku/core": "0.0.31-39f8920.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
+        "@waku/message-hash": "0.1.15-39f8920.0",
+        "@waku/relay": "0.0.14-39f8920.0",
+        "@waku/utils": "0.0.19-39f8920.0"
       },
       "peerDependenciesMeta": {
         "@libp2p/bootstrap": {
@@ -1442,12 +1442,12 @@
       }
     },
     "node_modules/@waku/utils": {
-      "version": "0.0.19-c33844e.0",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.19-c33844e.0.tgz",
-      "integrity": "sha512-SZzda4wszJsnXC7gxstfoE+ViWhwD4JbGFnwMgqTRJ2R5hsle5CJJ6WEM+1Ai1j9I4jij6qP6Xx+dEZri0zgXA==",
+      "version": "0.0.19-39f8920.0",
+      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.19-39f8920.0.tgz",
+      "integrity": "sha512-2+l68rc4YI58W6VALxtotw2f/5AZkECuh6lzkfeXB9zmc7/xAZEmAe/WtANAcs2ex8z+cJA03IHYi+LiGTF2Zg==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/interfaces": "0.0.26-39f8920.0",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
         "uint8arrays": "^5.0.1"
@@ -1456,7 +1456,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@waku/interfaces": "0.0.26-c33844e.0"
+        "@waku/interfaces": "0.0.26-39f8920.0"
       },
       "peerDependenciesMeta": {
         "@waku/interfaces": {

--- a/examples/dogfooding/package-lock.json
+++ b/examples/dogfooding/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@libp2p/peer-id": "^4.1.2",
-        "@waku/sdk": "0.0.26-16e9116.0",
+        "@waku/sdk": "0.0.27-c33844e.0",
         "protobufjs": "^7.3.0"
       },
       "devDependencies": {
@@ -52,12 +52,12 @@
       "integrity": "sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA=="
     },
     "node_modules/@chainsafe/libp2p-gossipsub": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-12.0.0.tgz",
-      "integrity": "sha512-ZuVIvzZjUaZXSPG6Ni9veVBLkZ4OkVp3zc3E8Y5EG/iIUSNVbHLFxweb3HuA12e3lIXLLurvy4vDyGWp4FpKow==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-13.2.0.tgz",
+      "integrity": "sha512-yKGXIJMLeNLa/XeI57HvQKhf1f4LRgBuV1Lrzv9Vo685Szr+qaBATUbMk/aLxpN2rMgibDIS5F8yaeuIUVPh8Q==",
       "dependencies": {
         "@libp2p/crypto": "^4.0.1",
-        "@libp2p/interface": "^1.1.2",
+        "@libp2p/interface": "^1.5.0",
         "@libp2p/interface-internal": "^1.0.7",
         "@libp2p/peer-id": "^4.0.5",
         "@libp2p/pubsub": "^9.0.8",
@@ -75,35 +75,29 @@
         "npm": ">=8.7.0"
       }
     },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/@libp2p/crypto": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.3.tgz",
-      "integrity": "sha512-q1XkPfSNk6PGSgwfxoeMoK2zstLRKEm16BwwMSs5JrVQv2FrqqUG0zrb6wLWEBnUHo+Us1yhf0/7/FyuIkDhdA==",
+    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/protons-runtime": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.4.0.tgz",
+      "integrity": "sha512-XfA++W/WlQOSyjUyuF5lgYBfXZUEMP01Oh1C2dSwZAlF2e/ZrMRPfWonXj6BGM+o8Xciv7w0tsRMKYwYEuQvaw==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
+        "uint8-varint": "^2.0.2",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^5.0.1"
       }
     },
     "node_modules/@chainsafe/libp2p-noise": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-14.1.0.tgz",
-      "integrity": "sha512-uHmptoxgMsfDIP7cQMQ4Zp9+y27oON5+gloBLXi+7EJpMhyvo7tjafUxRILwLofzeAtfaF3ZHraoXRFUSbhK2Q==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-15.1.1.tgz",
+      "integrity": "sha512-66EPS8gFTkb1jVCiJoY3+ulG/ZTef7kiNZZZvUOUzsLIZYQTi+7pIDBpgmolzSXdsFb8I2hl5mZsvcbzVZB5gg==",
       "dependencies": {
         "@chainsafe/as-chacha20poly1305": "^0.1.0",
         "@chainsafe/as-sha256": "^0.4.1",
-        "@libp2p/crypto": "^3.0.0",
-        "@libp2p/interface": "^1.0.0",
+        "@libp2p/crypto": "^4.0.0",
+        "@libp2p/interface": "^1.5.0",
         "@libp2p/peer-id": "^4.0.0",
-        "@noble/ciphers": "^0.4.0",
+        "@noble/ciphers": "^0.6.0",
         "@noble/curves": "^1.1.0",
         "@noble/hashes": "^1.3.1",
-        "it-byte-stream": "^1.0.0",
         "it-length-prefixed": "^9.0.1",
         "it-length-prefixed-stream": "^1.0.0",
         "it-pair": "^2.0.6",
@@ -375,53 +369,55 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
     "node_modules/@libp2p/bootstrap": {
-      "version": "10.0.25",
-      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-10.0.25.tgz",
-      "integrity": "sha512-yHvP7U9GilkxMbx4qmDLfziaqfmKf64rYS4yVitN+7TADDMU/nvspnukgdmHOPd3EtB7YYzTQXb+QLxX6KcklA==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-10.1.5.tgz",
+      "integrity": "sha512-cXn/Wl7X4uaVGRyh/uSU/crRbhsPkyzH59hzoLP3727f7w82o+sIHVr4SkJcJewt+LZELBLgkJTibZxAntA1dA==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/peer-id": "^4.1.3",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
         "@multiformats/mafmt": "^12.1.6",
         "@multiformats/multiaddr": "^12.2.3"
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-3.0.4.tgz",
-      "integrity": "sha512-FzSwBo+RJOUzdzEwug5ZL4dAGKwEBWTLzj+EmUTHHY6c87+oLh571DQk/w0oYObSD9hYbcKePgSBaZeBx0JaZg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.9.tgz",
+      "integrity": "sha512-8Cf2VKh0uC/rQLvTLSloIOMqUvf4jsSTHXgjWQRf47lDNJlNNI0wSv2S6gakT72GZsRV/jCjYwKPqRlsa5S0iA==",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@noble/curves": "^1.1.0",
-        "@noble/hashes": "^1.3.1",
-        "multiformats": "^13.0.0",
-        "node-forge": "^1.1.0",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
+        "@libp2p/interface": "^1.7.0",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "asn1js": "^3.0.5",
+        "multiformats": "^13.1.0",
+        "protons-runtime": "^5.4.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/identify": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-1.0.21.tgz",
-      "integrity": "sha512-wUpgXK1pCrd1wkG1vgkRe+TRHMv+SvR206o5x0srcifjGByXHwKzmTgwYK8dVVVA7SITsuobxVRuELl6OOAaCg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-2.1.5.tgz",
+      "integrity": "sha512-uVghY2KfZ3ffDkPmcivfiRDlq1h5rCcoHAW+Kb7JF2qrDfg6BgHAn6IRN4pe/DnYXOuJXIIm6+jjcReTPGBKBQ==",
       "dependencies": {
-        "@libp2p/interface": "^1.3.1",
-        "@libp2p/interface-internal": "^1.2.0",
-        "@libp2p/peer-id": "^4.1.1",
-        "@libp2p/peer-record": "^7.0.16",
-        "@multiformats/multiaddr": "^12.2.1",
-        "@multiformats/multiaddr-matcher": "^1.2.0",
-        "it-protobuf-stream": "^1.1.2",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/peer-record": "^7.0.25",
+        "@multiformats/multiaddr": "^12.2.3",
+        "@multiformats/multiaddr-matcher": "^1.2.1",
+        "it-drain": "^3.0.7",
+        "it-parallel": "^3.0.7",
+        "it-protobuf-stream": "^1.1.3",
         "protons-runtime": "^5.4.0",
         "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.3",
+        "uint8arrays": "^5.1.0",
         "wherearewe": "^2.0.1"
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.4.1.tgz",
-      "integrity": "sha512-lYrvNn7vggL8EVN7ZcGeK4Kf03aKlSD5zW6aBu297GFyXGvpWXJ+qj+fJzmCmXhZqAyI62IXZJ2bpJgI6022IQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.7.0.tgz",
+      "integrity": "sha512-/zFyaIaIGW0aihhsH7/93vQdpWInUzFocxF11RO/029Y6h0SVjs24HHbils+DqaFDTqN+L7oNlBx2rM2MnmTjA==",
       "dependencies": {
         "@multiformats/multiaddr": "^12.2.3",
         "it-pushable": "^3.2.3",
@@ -432,35 +428,36 @@
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-1.2.3.tgz",
-      "integrity": "sha512-0wN+G/QZqQupyQFY/x/l4oiqsuXfs1UqfdL4cozHjRHnTdpjlEfyU+CsZUtZoFDs8vXGJ0k2GFFkZdVrDJhlBg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-1.3.4.tgz",
+      "integrity": "sha512-8x/0sdeH8T16yZ9t/Cfja0ms6Ho9fF3riX56WhQrNxMU6C1sIgAFmzUNzHLxxOR+rkKyL9cyXIyB+RcBf4gzjA==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/peer-collections": "^5.2.3",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-collections": "^5.2.9",
         "@multiformats/multiaddr": "^12.2.3",
+        "progress-events": "^1.0.0",
         "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.14.tgz",
-      "integrity": "sha512-EUM3gV2eC35D2Mvc7XTQFxGEX7bD1K5K9LmTMVtTzJWgC1Svdp85NMWThxj7X+tf5SC/N556h3pKSM+hbdl9Zg==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.20.tgz",
+      "integrity": "sha512-TTh2dhHsOTAlMPxSa9ncFPHa/0jTt+0AQxwHdlxg/OGLAgc9VRhnrhHUbJZp07Crcw4T/MOfS4KhjlxgqYgJRw==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
+        "@libp2p/interface": "^1.7.0",
         "@multiformats/multiaddr": "^12.2.3",
-        "debug": "^4.3.4",
         "interface-datastore": "^8.2.11",
-        "multiformats": "^13.1.0"
+        "multiformats": "^13.1.0",
+        "weald": "^1.0.2"
       }
     },
     "node_modules/@libp2p/mplex": {
-      "version": "10.0.25",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-10.0.25.tgz",
-      "integrity": "sha512-9Ijgh4V3I6yhHHCiGQr+hKpRXgC3kcrqjmUdrDPJdoUnrIzSQluvH4yFhXPSyiVKwACjroPmqrUTchlVxxGATA==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-10.1.5.tgz",
+      "integrity": "sha512-NdT9ak8omeJZvdJhzsKSSeHBZlP+3sl68UbrpfVanWebQVuNqw7UOLURKtXnRd7II7siXt37Yq6W2km7VIT1yQ==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/utils": "^5.4.3",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/utils": "^5.4.9",
         "it-pipe": "^3.0.1",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.1",
@@ -470,11 +467,11 @@
       }
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-5.1.11.tgz",
-      "integrity": "sha512-aYsyj+TlBsuwNXca42okJH581LFjzHjg2tulCEv8kBKX+xZXyTu9lOk5PyqrGuEXQjm3Zs1erMTveX2hPTP24Q==",
+      "version": "5.1.17",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-5.1.17.tgz",
+      "integrity": "sha512-QOMGjCzKGf/W+qzWw5OxaqLEYhK45XjMCxGJYQ7L5eUkcwAv6rlPZAYw6YslaMLpJTa61/yfh8D4u7EuoMFsUw==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
+        "@libp2p/interface": "^1.7.0",
         "it-length-prefixed": "^9.0.4",
         "it-length-prefixed-stream": "^1.1.7",
         "it-stream-types": "^2.0.1",
@@ -486,62 +483,47 @@
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-5.2.3.tgz",
-      "integrity": "sha512-0gwsB+Tmlfv/oDpDRySmWydjTKnfapZFaagP+Gy6Eu/TMDUR/c5hdeYuFyOfFNV2azERyMKvLEhTvnYJ/c3S/g==",
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-5.2.9.tgz",
+      "integrity": "sha512-8gBmzQlCWjjb+FSQBKK33T25Y5Df/8FWCXFtJDsprVxVUzDOQoibQJ5Tb4Y+mb96HUhNzoaRWVEamB78MMB3DA==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/peer-id": "^4.1.3",
-        "@libp2p/utils": "^5.4.3"
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9"
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.1.3.tgz",
-      "integrity": "sha512-VQxxuisVqd3n+CIohP1elDYb1JeDb+JrYp/fhfMpgWvP9gqrQSBRS4LOHWZhvkyJ79TmyOkjEHjgS0Poc0lduQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.2.4.tgz",
+      "integrity": "sha512-mvvsVxt4HkF14BrTNKbqr14VObW+KBJBWu1Oe6BFCoDttGMQLaI+PdduE1r6Tquntv5IONBqoITgD7ow5dQ+vQ==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
+        "@libp2p/interface": "^1.7.0",
         "multiformats": "^13.1.0",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-id-factory": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-4.1.3.tgz",
-      "integrity": "sha512-lTvVXUMN8gYWdLS2bimaUzzED/y+PyQj1JbdUigBFIvFrFlxM3+jPWdY/552UidjNR6zAApRI5DwmmrNGsyxjA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id-factory/-/peer-id-factory-4.2.4.tgz",
+      "integrity": "sha512-NDQ/qIWpcAG/6xQjyut6xCkrYYAoCaI/33Z+7yzo5qFODwLfNonLzSTasnA6jhuvHn33aHnD1qhdpFkmstxtNQ==",
       "dependencies": {
-        "@libp2p/crypto": "^4.1.3",
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/peer-id": "^4.1.3",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/@libp2p/peer-id-factory/node_modules/@libp2p/crypto": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.3.tgz",
-      "integrity": "sha512-q1XkPfSNk6PGSgwfxoeMoK2zstLRKEm16BwwMSs5JrVQv2FrqqUG0zrb6wLWEBnUHo+Us1yhf0/7/FyuIkDhdA==",
-      "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
         "protons-runtime": "^5.4.0",
         "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-7.0.19.tgz",
-      "integrity": "sha512-F4f6sqg5uaSFIHEoCs8GlfH6/RjBNN4d29TPGueexfK8Sp78v0jmOBCl0JkGsnh3CmLzZG/td9o7nQvmQHusbg==",
+      "version": "7.0.25",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-7.0.25.tgz",
+      "integrity": "sha512-b54P3cSeQniW/HPJjBVbeF3KaVUQkWa431gotuIFUS1PYgtz69uzkRrVY6Qt+RBb4R4fcmH4K4jWyZi3xyLGfQ==",
       "dependencies": {
-        "@libp2p/crypto": "^4.1.3",
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/peer-id": "^4.1.3",
-        "@libp2p/utils": "^5.4.3",
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9",
         "@multiformats/multiaddr": "^12.2.3",
         "protons-runtime": "^5.4.0",
         "uint8-varint": "^2.0.4",
@@ -549,30 +531,15 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/peer-record/node_modules/@libp2p/crypto": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.3.tgz",
-      "integrity": "sha512-q1XkPfSNk6PGSgwfxoeMoK2zstLRKEm16BwwMSs5JrVQv2FrqqUG0zrb6wLWEBnUHo+Us1yhf0/7/FyuIkDhdA==",
-      "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
     "node_modules/@libp2p/peer-store": {
-      "version": "10.0.20",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-10.0.20.tgz",
-      "integrity": "sha512-P+Kwn79UNfKVCb1F3Z1QXurHY2Yi5qSf3n1FCfC/aRe6GRfe68IYYrn06Q0ZmCbfS1MA95v3BdlRFXZNvPysow==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-10.1.5.tgz",
+      "integrity": "sha512-JqQcIcxZS7kicCPabGRyrKD+qZlOdaooL00hdHogVb4MIMqfjiQMmOEpzIvTQLCKHKM2mmfnV3P7kc6hYzPq8g==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/peer-collections": "^5.2.3",
-        "@libp2p/peer-id": "^4.1.3",
-        "@libp2p/peer-record": "^7.0.19",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/peer-collections": "^5.2.9",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/peer-record": "^7.0.25",
         "@multiformats/multiaddr": "^12.2.3",
         "interface-datastore": "^8.2.11",
         "it-all": "^3.0.6",
@@ -584,45 +551,30 @@
       }
     },
     "node_modules/@libp2p/ping": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-1.0.20.tgz",
-      "integrity": "sha512-utcwxEyU1SpQARNlh2ZUb9O0tb/oH1llVAXBqv9dPHRcxdP3hnSEGKRarIE+2XLE7XmLW3jg1WsOa6hQHmc3UA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-1.1.5.tgz",
+      "integrity": "sha512-CeRpXdtljyWr/UNmrojnZbyI/oDkdu6duCGtWnnDFmPS2tR4Rxr2C8sKA1iAvhgvRFhh5vrTmlB1QUbUWHHRCg==",
       "dependencies": {
-        "@libp2p/crypto": "^4.1.3",
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/interface-internal": "^1.2.3",
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
         "@multiformats/multiaddr": "^12.2.3",
         "it-first": "^3.0.6",
         "it-pipe": "^3.0.1",
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/ping/node_modules/@libp2p/crypto": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.3.tgz",
-      "integrity": "sha512-q1XkPfSNk6PGSgwfxoeMoK2zstLRKEm16BwwMSs5JrVQv2FrqqUG0zrb6wLWEBnUHo+Us1yhf0/7/FyuIkDhdA==",
-      "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
     "node_modules/@libp2p/pubsub": {
-      "version": "9.0.20",
-      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-9.0.20.tgz",
-      "integrity": "sha512-TqQMnTubga40y9tOLRCwddeU28/BR2ONneUhrpAnxM72f6ukwSIlrD2c1ryqktGGF0W0elVBiHonigMXWBhfjQ==",
+      "version": "9.0.26",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-9.0.26.tgz",
+      "integrity": "sha512-69sFv5DAHSXrQdu4THX9WSZuEfCjEbbk6bKiTtbNGpq1Vaf57rjsTWk/EXMS/veeMl95xJs3/BR7dQal2PtJmw==",
       "dependencies": {
-        "@libp2p/crypto": "^4.1.3",
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/interface-internal": "^1.2.3",
-        "@libp2p/peer-collections": "^5.2.3",
-        "@libp2p/peer-id": "^4.1.3",
-        "@libp2p/utils": "^5.4.3",
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/peer-collections": "^5.2.9",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/utils": "^5.4.9",
         "it-length-prefixed": "^9.0.4",
         "it-pipe": "^3.0.1",
         "it-pushable": "^3.2.3",
@@ -632,30 +584,15 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/pubsub/node_modules/@libp2p/crypto": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.3.tgz",
-      "integrity": "sha512-q1XkPfSNk6PGSgwfxoeMoK2zstLRKEm16BwwMSs5JrVQv2FrqqUG0zrb6wLWEBnUHo+Us1yhf0/7/FyuIkDhdA==",
-      "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
     "node_modules/@libp2p/utils": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-5.4.3.tgz",
-      "integrity": "sha512-sVctV0zOITR2HJKK+oiWJDvvTtWb0f+nCgf5iO2ibUxy9IpM0843JFXZZ8skf/sJIelMoZftz9AtsuWsQcXdVw==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-5.4.9.tgz",
+      "integrity": "sha512-0fRdX98WqhTmXU2WEVLegLFxs/kKTtUHanHk5Lzs4oGsIzlPHR7zE6lj/U1WfsFA+Xo1eYQpNLiXEL29hG+Nyw==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.2",
-        "@libp2p/crypto": "^4.1.3",
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/logger": "^4.0.14",
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/logger": "^4.0.20",
         "@multiformats/multiaddr": "^12.2.3",
         "@multiformats/multiaddr-matcher": "^1.2.1",
         "@sindresorhus/fnv1a": "^3.1.0",
@@ -675,34 +612,21 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/utils/node_modules/@libp2p/crypto": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.3.tgz",
-      "integrity": "sha512-q1XkPfSNk6PGSgwfxoeMoK2zstLRKEm16BwwMSs5JrVQv2FrqqUG0zrb6wLWEBnUHo+Us1yhf0/7/FyuIkDhdA==",
-      "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
     "node_modules/@libp2p/websockets": {
-      "version": "8.0.25",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-8.0.25.tgz",
-      "integrity": "sha512-GNpwwQiYFywHsP/QXn2n5Dspuofl9v4nI+B7+1vVVmzgkIurzDnNc0IDWNvfETm1Ci3SPnEi0SkYqhtB4idJLQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-8.2.0.tgz",
+      "integrity": "sha512-UNjqkQ8/emnYswp1ohIIuZCnhI5DlvWF9IaIND2MoTCDavi7yubWfMp8jSWBsAqPnMeLMO8MQ6YlOo4FFC104Q==",
       "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/utils": "^5.4.3",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/utils": "^5.4.9",
         "@multiformats/mafmt": "^12.1.6",
         "@multiformats/multiaddr": "^12.2.3",
         "@multiformats/multiaddr-to-uri": "^10.0.1",
         "@types/ws": "^8.5.10",
         "it-ws": "^6.1.1",
         "p-defer": "^4.0.1",
+        "progress-events": "^1.0.0",
+        "race-signal": "^1.0.2",
         "wherearewe": "^2.0.1",
         "ws": "^8.17.0"
       }
@@ -771,17 +695,17 @@
       }
     },
     "node_modules/@noble/ciphers": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.4.1.tgz",
-      "integrity": "sha512-QCOA9cgf3Rc33owG0AYBB9wszz+Ul2kramWN8tXG44Gyciud/tbkEqvxRF/IpqQaBpRBNi9f4jdNxqB2CQCIXg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.6.0.tgz",
+      "integrity": "sha512-mIbq/R9QXk5/cTfESb1OKtyFnk7oc1Om/8onA1158K9/OZUQFDEVy55jVTato+xmp3XX6F6Qh0zz0Nc1AxAlRQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.5.0.tgz",
+      "integrity": "sha512-J5EKamIHnKPyClwVrzmaf5wSdQXgdHcPZIZLu3bwnbeCx8/7NPK5q2ZBWF+5FvYGByjiQQsJYX6jfgB2wDPn3A==",
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -1296,15 +1220,15 @@
       "dev": true
     },
     "node_modules/@waku/core": {
-      "version": "0.0.30-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.30-16e9116.0.tgz",
-      "integrity": "sha512-DZByXVkOcriOWPjvJgzVYFv5Ih7z0/dLCq8mM97gqChYVC8sOZ09RvBWcoeSF9lj+R5pEYHxqY1y7Vtiz1Mizw==",
+      "version": "0.0.31-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.31-c33844e.0.tgz",
+      "integrity": "sha512-L0UyMsxn8KC0sT3J5lDxlVHZBEct/e0ykrrK/ohhP1IvCeYlCdHjDp3yQgzm3E/Gq+1NAMiDh+Qa2RvaS7e2bw==",
       "dependencies": {
-        "@libp2p/ping": "^1.0.12",
-        "@waku/enr": "0.0.24-16e9116.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/proto": "0.0.8-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0",
+        "@libp2p/ping": "^1.1.2",
+        "@waku/enr": "0.0.25-c33844e.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/proto": "0.0.8-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0",
         "debug": "^4.3.4",
         "it-all": "^3.0.4",
         "it-length-prefixed": "^9.0.4",
@@ -1318,11 +1242,11 @@
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
-        "@waku/enr": "0.0.24-16e9116.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/proto": "0.0.8-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0",
-        "libp2p": "^1.1.2"
+        "@waku/enr": "0.0.25-c33844e.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/proto": "0.0.8-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0",
+        "libp2p": "^1.8.1"
       },
       "peerDependenciesMeta": {
         "@multiformats/multiaddr": {
@@ -1334,15 +1258,15 @@
       }
     },
     "node_modules/@waku/discovery": {
-      "version": "0.0.3-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/discovery/-/discovery-0.0.3-16e9116.0.tgz",
-      "integrity": "sha512-8it69PuYcTbrhIFDElbMmCiu+s7WHRn/GLrtH2GmEKQXLdJgqzpVHh/boh/+dr4jmprW1lA38yjmtnEuttsBDw==",
+      "version": "0.0.4-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/discovery/-/discovery-0.0.4-c33844e.0.tgz",
+      "integrity": "sha512-Zy2pDwhdy8RhhjfCYCvKj0xMnH/fu02T8d8qMIY8TYjhobg3+xMdWrGjNQQLF26+1eKHdYVft7F0aULVqYrx+Q==",
       "dependencies": {
-        "@waku/core": "0.0.30-16e9116.0",
-        "@waku/enr": "0.0.24-16e9116.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/proto": "0.0.8-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0",
+        "@waku/core": "0.0.31-c33844e.0",
+        "@waku/enr": "0.0.25-c33844e.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/proto": "0.0.8-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0",
         "debug": "^4.3.4",
         "dns-query": "^0.11.2",
         "hi-base32": "^0.5.1",
@@ -1352,12 +1276,12 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@libp2p/interface": "^1.1.2",
-        "@waku/core": "0.0.30-16e9116.0",
-        "@waku/enr": "0.0.24-16e9116.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/proto": "0.0.8-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0"
+        "@libp2p/interface": "^1.6.3",
+        "@waku/core": "0.0.31-c33844e.0",
+        "@waku/enr": "0.0.25-c33844e.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/proto": "0.0.8-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0"
       },
       "peerDependenciesMeta": {
         "@libp2p/interface": {
@@ -1369,16 +1293,16 @@
       }
     },
     "node_modules/@waku/enr": {
-      "version": "0.0.24-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.24-16e9116.0.tgz",
-      "integrity": "sha512-EijdCYvc8TEnWS2nyscH9RojRpeUi6aSnyt5LIpw6r3oo74X/KiUiRhlqHn8OxfwFSzkUpGS0QgawPpbBAkEbQ==",
+      "version": "0.0.25-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.25-c33844e.0.tgz",
+      "integrity": "sha512-e5z0yCmI+clxO4V3nkNE5dTnswF4UIjQXpWMChr/54ExrJ2dFOHSZfs3jgDa3ZXt23rKa0AuHFJAxYOhModvQA==",
       "dependencies": {
         "@ethersproject/rlp": "^5.7.0",
-        "@libp2p/crypto": "^4.0.0",
-        "@libp2p/peer-id": "^4.0.4",
+        "@libp2p/crypto": "^4.1.6",
+        "@libp2p/peer-id": "^4.2.1",
         "@multiformats/multiaddr": "^12.0.0",
         "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.18-16e9116.0",
+        "@waku/utils": "0.0.19-c33844e.0",
         "debug": "^4.3.4",
         "js-sha3": "^0.9.2"
       },
@@ -1387,8 +1311,8 @@
       },
       "peerDependencies": {
         "@multiformats/multiaddr": "^12.0.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0"
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0"
       },
       "peerDependenciesMeta": {
         "@multiformats/multiaddr": {
@@ -1399,47 +1323,32 @@
         }
       }
     },
-    "node_modules/@waku/enr/node_modules/@libp2p/crypto": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.3.tgz",
-      "integrity": "sha512-q1XkPfSNk6PGSgwfxoeMoK2zstLRKEm16BwwMSs5JrVQv2FrqqUG0zrb6wLWEBnUHo+Us1yhf0/7/FyuIkDhdA==",
-      "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
     "node_modules/@waku/interfaces": {
-      "version": "0.0.25-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.25-16e9116.0.tgz",
-      "integrity": "sha512-/vWGjEKk561vEuMUfvtAZ1rT7Z4LXIDk+ZmqpKeThcj/SZztXjkyo6GZCgICLFtq0igoLnNjJhEoDz1J/A2E/A==",
+      "version": "0.0.26-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.26-c33844e.0.tgz",
+      "integrity": "sha512-hsSXaqXKbd/fdnDE1sRiw8XYPDekNfkFFo0Glxe6tAsndwZfjLnQabejTQmAPCQouNEU5LK8B5u1y6MwQoM36w==",
       "dependencies": {
-        "@waku/proto": "0.0.8-16e9116.0"
+        "@waku/proto": "0.0.8-c33844e.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@waku/message-hash": {
-      "version": "0.1.14-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/message-hash/-/message-hash-0.1.14-16e9116.0.tgz",
-      "integrity": "sha512-PCaxjxn/2pfbhN8RHk74DLhFEKTbhyeV29FK1H0hUoDnp7RR3M8x5OD/ZdeVhO/CeyYBYSwATwNg0djbArP+ug==",
+      "version": "0.1.15-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/message-hash/-/message-hash-0.1.15-c33844e.0.tgz",
+      "integrity": "sha512-PVjXm2tv90IO66sLPM0iJ+eav4foQPDpZ/nurqixwmWBRocq4ydQKlj3D7y7epJY5uC6mgQ63282Br2oVaim5A==",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/utils": "0.0.18-16e9116.0"
+        "@waku/utils": "0.0.19-c33844e.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0"
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0"
       },
       "peerDependenciesMeta": {
         "@waku/interfaces": {
@@ -1448,9 +1357,9 @@
       }
     },
     "node_modules/@waku/proto": {
-      "version": "0.0.8-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.8-16e9116.0.tgz",
-      "integrity": "sha512-i1L+t/tsAnZEdntr5gI1OrIcXEr+RafKTCrV7KYfs+VBrTHGKS4MIiVWzAPHgolA6mxAF34A0k4WV6HXF0z1nA==",
+      "version": "0.0.8-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.8-c33844e.0.tgz",
+      "integrity": "sha512-k2KkeVQB8yq163p1yXMLPwEISv9JiMeouxg02QiOJJnnKVuSl240b6cJ3HhCeVSfSH0TNNu616qwzdQUpL2xcA==",
       "dependencies": {
         "protons-runtime": "^5.4.0"
       },
@@ -1459,29 +1368,29 @@
       }
     },
     "node_modules/@waku/relay": {
-      "version": "0.0.13-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.13-16e9116.0.tgz",
-      "integrity": "sha512-lB7irp8ANzcpweVaZHGGGw8qhQCmi/wWXv7zdwWyRpcgKW7CJrI8nJtS0BshbhfSVSZBe0OmUfahD4Avx4EZqA==",
+      "version": "0.0.14-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.14-c33844e.0.tgz",
+      "integrity": "sha512-JY5o9b+OPS+kHQdThrNn3U6/dwcBS9o6XrOLixtYiIo9kZyj0VnXyuEnxaCd0veMqZW0Netc07HhvDHHCr/5pQ==",
       "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "^12.0.0",
+        "@chainsafe/libp2p-gossipsub": "^13.1.0",
         "@noble/hashes": "^1.3.2",
-        "@waku/core": "0.0.30-16e9116.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/proto": "0.0.8-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0",
+        "@waku/core": "0.0.31-c33844e.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/proto": "0.0.8-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
-        "fast-check": "^3.15.1"
+        "fast-check": "^3.19.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@chainsafe/libp2p-gossipsub": "^12.0.0",
-        "@waku/core": "0.0.30-16e9116.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/proto": "0.0.8-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0"
+        "@waku/core": "0.0.31-c33844e.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/proto": "0.0.8-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0"
       },
       "peerDependenciesMeta": {
         "@chainsafe/libp2p-gossipsub": {
@@ -1493,35 +1402,35 @@
       }
     },
     "node_modules/@waku/sdk": {
-      "version": "0.0.26-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.26-16e9116.0.tgz",
-      "integrity": "sha512-2KtoGoy7EfbLJucaFpeeTUXGMgT1y4naO+9Wp+pcGpk83VT5+QiyNaduQBTOs2aAVVcans/yS/X1N+d8A7nAPA==",
+      "version": "0.0.27-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.27-c33844e.0.tgz",
+      "integrity": "sha512-GZ6hKw5d+C6O6q92sgcMMKSE97ejEE6F9MfaKWIKsVBkSRBEe18c4pd/w6JPmDZZ9CEqHwMpShuDUq3qGcUb2w==",
       "dependencies": {
-        "@chainsafe/libp2p-noise": "^14.1.0",
-        "@libp2p/bootstrap": "^10.0.16",
-        "@libp2p/identify": "^1.0.11",
-        "@libp2p/mplex": "^10.0.12",
-        "@libp2p/ping": "^1.0.12",
-        "@libp2p/websockets": "^8.0.11",
+        "@chainsafe/libp2p-noise": "^15.1.0",
+        "@libp2p/bootstrap": "^10.1.2",
+        "@libp2p/identify": "^2.1.2",
+        "@libp2p/mplex": "^10.1.2",
+        "@libp2p/ping": "^1.1.2",
+        "@libp2p/websockets": "^8.1.4",
         "@noble/hashes": "^1.3.3",
-        "@waku/core": "0.0.30-16e9116.0",
-        "@waku/discovery": "0.0.3-16e9116.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/proto": "0.0.8-16e9116.0",
-        "@waku/relay": "0.0.13-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0",
-        "libp2p": "^1.1.2"
+        "@waku/core": "0.0.31-c33844e.0",
+        "@waku/discovery": "0.0.4-c33844e.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/proto": "0.0.8-c33844e.0",
+        "@waku/relay": "0.0.14-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0",
+        "libp2p": "^1.8.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@libp2p/bootstrap": "^10",
-        "@waku/core": "0.0.30-16e9116.0",
-        "@waku/interfaces": "0.0.25-16e9116.0",
-        "@waku/message-hash": "0.1.14-16e9116.0",
-        "@waku/relay": "0.0.13-16e9116.0",
-        "@waku/utils": "0.0.18-16e9116.0"
+        "@waku/core": "0.0.31-c33844e.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
+        "@waku/message-hash": "0.1.15-c33844e.0",
+        "@waku/relay": "0.0.14-c33844e.0",
+        "@waku/utils": "0.0.19-c33844e.0"
       },
       "peerDependenciesMeta": {
         "@libp2p/bootstrap": {
@@ -1533,12 +1442,12 @@
       }
     },
     "node_modules/@waku/utils": {
-      "version": "0.0.18-16e9116.0",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.18-16e9116.0.tgz",
-      "integrity": "sha512-61S25ACw4JuyQyvdcQz8Tgk3GPH7pWN6YOjvZIiYU1hZnwIWfA6vtvtvkGThsx7qHUuRGetB748Xl2NUVa0QSA==",
+      "version": "0.0.19-c33844e.0",
+      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.19-c33844e.0.tgz",
+      "integrity": "sha512-SZzda4wszJsnXC7gxstfoE+ViWhwD4JbGFnwMgqTRJ2R5hsle5CJJ6WEM+1Ai1j9I4jij6qP6Xx+dEZri0zgXA==",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "@waku/interfaces": "0.0.25-16e9116.0",
+        "@waku/interfaces": "0.0.26-c33844e.0",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
         "uint8arrays": "^5.0.1"
@@ -1547,7 +1456,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@waku/interfaces": "0.0.25-16e9116.0"
+        "@waku/interfaces": "0.0.26-c33844e.0"
       },
       "peerDependenciesMeta": {
         "@waku/interfaces": {
@@ -2413,9 +2322,9 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -2423,7 +2332,7 @@
         "get-func-name": "^2.0.2",
         "loupe": "^2.3.6",
         "pathval": "^1.1.1",
-        "type-detect": "^4.0.8"
+        "type-detect": "^4.1.0"
       },
       "engines": {
         "node": ">=4"
@@ -2766,6 +2675,11 @@
         "it-sort": "^3.0.4",
         "it-take": "^3.0.4"
       }
+    },
+    "node_modules/datastore-core/node_modules/interface-store": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
+      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
     },
     "node_modules/debug": {
       "version": "4.3.5",
@@ -3727,9 +3641,9 @@
       "dev": true
     },
     "node_modules/fast-check": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.19.0.tgz",
-      "integrity": "sha512-CO2JX/8/PT9bDGO1iXa5h5ey1skaKI1dvecERyhH4pp3PGjwd3KIjMAXEg79Ps9nclsdt4oPbfqiAnLU0EwrAQ==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.21.0.tgz",
+      "integrity": "sha512-QpmbiqRFRZ+SIlBJh6xi5d/PgXciUc/xWKc4Vi2RWEHHIRx6oM3f0fWNna++zP9VB5HUBTObUK9gTKQP3vVcrQ==",
       "funding": [
         {
           "type": "individual",
@@ -4576,18 +4490,18 @@
       "dev": true
     },
     "node_modules/interface-datastore": {
-      "version": "8.2.11",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.11.tgz",
-      "integrity": "sha512-9E0iXehfp/j0UbZ2mvlYB4K9pP7uQBCppfuy8WHs1EHF6wLQrM9+zwyX+8Qt6HnH4GKZRyXX/CNXm6oD4+QYgA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.0.tgz",
+      "integrity": "sha512-RM/rTSmRcnoCwGZIHrPm+nlGYVoT4R0lcFvNnDyhdFT4R6BuHHhfFP47UldVEjs98SfxLuMhaNMsyjI918saHw==",
       "dependencies": {
-        "interface-store": "^5.0.0",
+        "interface-store": "6.0.0",
         "uint8arrays": "^5.0.2"
       }
     },
     "node_modules/interface-store": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.8.tgz",
-      "integrity": "sha512-7na81Uxkl0vqk0CBPO5PvyTkdaJBaezwUJGsMOz7riPOq0rJt+7W31iaopaMICWea/iykUsvNlPx/Tc+MxC3/w=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.0.tgz",
+      "integrity": "sha512-HkjsDPsjA7SKkCr+TH1elUQApAAM3X3JPwrz3vFzaf614wI+ZD6GVvwKGZCHYcbSRqeZP/uzVPqezzeISeo5kA=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -5075,9 +4989,9 @@
       "integrity": "sha512-HXZWbxCgQZJfrv5rXvaVeaayXED8nTKx9tj9fpBhmcUJcedVZshMMMqTj0RG2+scGypb9Ut1zd1ifbf3lA8L+Q=="
     },
     "node_modules/it-byte-stream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.0.12.tgz",
-      "integrity": "sha512-gBDnL9GVXLrnF4h02nWYDSHh41dRlzlu2REw6xu+TZyHKauJ9Vo0W4oFM4eXfMwtT8IM6AovCBJPR1ISc4kkZg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.0.tgz",
+      "integrity": "sha512-WWponBWdKEa6o2U3NX+wGMY8X1EkWXcQvpC+3CUqKb4ZzK30q3EPqiTjFxLf9tNVgdF/MNAtx/XclpVfgaz9KQ==",
       "dependencies": {
         "it-queueless-pushable": "^1.0.0",
         "it-stream-types": "^2.0.1",
@@ -5103,11 +5017,10 @@
       "integrity": "sha512-ExIewyK9kXKNAplg2GMeWfgjUcfC1FnUXz/RPfAvIXby+w7U4b3//5Lic0NV03gXT8O/isj5Nmp6KiY0d45pIQ=="
     },
     "node_modules/it-length-prefixed": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.4.tgz",
-      "integrity": "sha512-lz28fykbG0jq7s5XtvlzGxO5BeSOw6ikymkRllxjL21V5VKLcvB4pHr9wPvEnsAJ2et1xpOk3BRTMq9XrhgKsg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.1.0.tgz",
+      "integrity": "sha512-kx2UTJuy7/lsT3QUzf50NjfxU1Z4P4wlvYp6YnR5Nc61P8XKfy+QtiJi1VLojA+Kea7vMbB4002rIij1Ol9hcw==",
       "dependencies": {
-        "err-code": "^3.0.1",
         "it-reader": "^6.0.1",
         "it-stream-types": "^2.0.1",
         "uint8-varint": "^2.0.1",
@@ -5120,9 +5033,9 @@
       }
     },
     "node_modules/it-length-prefixed-stream": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-1.1.8.tgz",
-      "integrity": "sha512-nchxgDiGS5R5UKwrvTznrLRUOh9oo9GCDkddc8OI/AVkkiLhuh1+pcTSZ15DBl6GwdB7lBD1edUixTzJ78jfUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-1.2.0.tgz",
+      "integrity": "sha512-vX7dzSl/2UMYYsAr0FQdPNVR5xYEETaeboZ+eXxNBjgARuvxnWA6OedW8lC5/J3ebMTC98JhA3eH76eTijUOsA==",
       "dependencies": {
         "it-byte-stream": "^1.0.0",
         "it-stream-types": "^2.0.1",
@@ -5187,9 +5100,9 @@
       }
     },
     "node_modules/it-protobuf-stream": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-1.1.4.tgz",
-      "integrity": "sha512-HEO7PqNYRnFsN4qxxXWD0aQV3ibsYBaB/nPucBXgZcnD3csPltigU4C+j2U/ahhOwB/AfXdHv4WCd/IIzeSIpg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-1.1.5.tgz",
+      "integrity": "sha512-H70idW45As3cEbU4uSoZ9IYHUIV3YM69/2mmXYR7gOlPabWjuyNi3/abK11geiiq3la27Sos/mXr68JljjKtEQ==",
       "dependencies": {
         "it-length-prefixed-stream": "^1.0.0",
         "it-stream-types": "^2.0.1",
@@ -5249,9 +5162,9 @@
       "integrity": "sha512-uqw3MRzf9to1SOLxaureGa73lK8k8ZB/asOApTAkvrzUqCznGtKNgPFH7uYIWlt4UuWq/hU6I+U4Fm5xpjN8Vg=="
     },
     "node_modules/it-ws": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.1.1.tgz",
-      "integrity": "sha512-oyk4eCeZto2lzWDnJOa3j1S2M+VOGKUh8isEf94ySoaL6IFlyie0T4P9E0ZUaIvX8LyJxYFHFKCt8Zk7Sm/XPQ==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.1.5.tgz",
+      "integrity": "sha512-uWjMtpy5HqhSd/LlrlP3fhYrr7rUfJFFMABv0F5d6n13Q+0glhZthwUKpEAVhDrXY95Tb1RB5lLqqef+QbVNaw==",
       "dependencies": {
         "@types/ws": "^8.2.2",
         "event-iterator": "^2.0.0",
@@ -5440,48 +5353,35 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-1.6.1.tgz",
-      "integrity": "sha512-d2dxXO5f1o2CRPZvU/9tMvb+zsy77zbXXKKNVrNjABd2Qe3d9hP2K9335flXfd99zUelH8dVMp8RTh4S25Fc2Q==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-1.9.2.tgz",
+      "integrity": "sha512-cvzSC3UM9A1w6kb3GO9+iqRwCg/c/4hF6RZTF0SyY5U3xVawXSQPMcB5td9d+20HcNrYm2uWKjlexORllAT2hA==",
       "dependencies": {
-        "@libp2p/crypto": "^4.1.3",
-        "@libp2p/interface": "^1.4.1",
-        "@libp2p/interface-internal": "^1.2.3",
-        "@libp2p/logger": "^4.0.14",
-        "@libp2p/multistream-select": "^5.1.11",
-        "@libp2p/peer-collections": "^5.2.3",
-        "@libp2p/peer-id": "^4.1.3",
-        "@libp2p/peer-id-factory": "^4.1.3",
-        "@libp2p/peer-store": "^10.0.20",
-        "@libp2p/utils": "^5.4.3",
+        "@libp2p/crypto": "^4.1.9",
+        "@libp2p/interface": "^1.7.0",
+        "@libp2p/interface-internal": "^1.3.4",
+        "@libp2p/logger": "^4.0.20",
+        "@libp2p/multistream-select": "^5.1.17",
+        "@libp2p/peer-collections": "^5.2.9",
+        "@libp2p/peer-id": "^4.2.4",
+        "@libp2p/peer-id-factory": "^4.2.4",
+        "@libp2p/peer-store": "^10.1.5",
+        "@libp2p/utils": "^5.4.9",
         "@multiformats/dns": "^1.0.6",
         "@multiformats/multiaddr": "^12.2.3",
         "@multiformats/multiaddr-matcher": "^1.2.1",
         "any-signal": "^4.1.1",
         "datastore-core": "^9.2.9",
         "interface-datastore": "^8.2.11",
+        "it-byte-stream": "^1.0.12",
         "it-merge": "^3.0.5",
         "it-parallel": "^3.0.7",
         "merge-options": "^3.0.4",
         "multiformats": "^13.1.0",
         "p-defer": "^4.0.1",
+        "progress-events": "^1.0.0",
         "race-event": "^1.3.0",
         "race-signal": "^1.0.2",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/crypto": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.1.3.tgz",
-      "integrity": "sha512-q1XkPfSNk6PGSgwfxoeMoK2zstLRKEm16BwwMSs5JrVQv2FrqqUG0zrb6wLWEBnUHo+Us1yhf0/7/FyuIkDhdA==",
-      "dependencies": {
-        "@libp2p/interface": "^1.4.1",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "asn1js": "^3.0.5",
-        "multiformats": "^13.1.0",
-        "protons-runtime": "^5.4.0",
-        "uint8arraylist": "^2.4.8",
         "uint8arrays": "^5.1.0"
       }
     },
@@ -5758,6 +5658,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true,
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -6338,9 +6239,9 @@
       }
     },
     "node_modules/protons-runtime": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.4.0.tgz",
-      "integrity": "sha512-XfA++W/WlQOSyjUyuF5lgYBfXZUEMP01Oh1C2dSwZAlF2e/ZrMRPfWonXj6BGM+o8Xciv7w0tsRMKYwYEuQvaw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.5.0.tgz",
+      "integrity": "sha512-EsALjF9QsrEk6gbCx3lmfHxVN0ah7nG3cY7GySD4xf4g8cr7g543zB88Foh897Sr1RQJ9yDCUsoT1i1H/cVUFA==",
       "dependencies": {
         "uint8-varint": "^2.0.2",
         "uint8arraylist": "^2.4.3",
@@ -6450,9 +6351,9 @@
       "integrity": "sha512-kaLm7axfOnahIqD3jQ4l1e471FIFcEGebXEnhxyLscuUzV8C94xVHtWEqDDXxll7+yu/6lW0w1Ff4HbtvHvOHg=="
     },
     "node_modules/race-signal": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.0.2.tgz",
-      "integrity": "sha512-o3xNv0iTcIDQCXFlF6fPAMEBRjFxssgGoRqLbg06m+AdzEXXLUmoNOoUHTVz2NoBI8hHwKFKoC6IqyNtWr2bww=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/race-signal/-/race-signal-1.1.0.tgz",
+      "integrity": "sha512-VqsW1uzCXfKBd2DhA3K3NhQlqQr04+5WQ7+kHpf1HzT01Q+ePSFWZdQHXKZPuLmm2eXTZM1XLO76cq15ZRAaEA=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -7533,9 +7434,9 @@
       }
     },
     "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "engines": {
         "node": ">=4"
       }
@@ -7820,6 +7721,34 @@
       "dev": true,
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/weald": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/weald/-/weald-1.0.2.tgz",
+      "integrity": "sha512-iG5cIuBwsPe1ZcoGGd4X6QYlepU1vLr4l4oWpzQWqeJPSo9B8bxxyE6xlnj3TCmThtha7gyVL+uuZgUFkPyfDg==",
+      "dependencies": {
+        "ms": "^3.0.0-canary.1",
+        "supports-color": "^9.4.0"
+      }
+    },
+    "node_modules/weald/node_modules/ms": {
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
+      }
+    },
+    "node_modules/weald/node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/webpack": {

--- a/examples/dogfooding/package.json
+++ b/examples/dogfooding/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@libp2p/peer-id": "^4.1.2",
-    "@waku/sdk": "0.0.27-c33844e.0",
+    "@waku/sdk": "0.0.27-39f8920.0",
     "protobufjs": "^7.3.0"
   },
   "devDependencies": {

--- a/examples/dogfooding/package.json
+++ b/examples/dogfooding/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@libp2p/peer-id": "^4.1.2",
-    "@waku/sdk": "0.0.26-16e9116.0",
+    "@waku/sdk": "0.0.27-c33844e.0",
     "protobufjs": "^7.3.0"
   },
   "devDependencies": {

--- a/examples/dogfooding/src/index.ts
+++ b/examples/dogfooding/src/index.ts
@@ -32,7 +32,9 @@ const messageSentEvent = new CustomEvent("messageSent");
 
 const wakuNode = async (): Promise<LightNode> => {
   return await createLightNode({
-    contentTopics: [DEFAULT_CONTENT_TOPIC],
+    networkConfig: {
+      contentTopics: [DEFAULT_CONTENT_TOPIC],
+    },
     defaultBootstrap: true,
   });
 };
@@ -43,14 +45,10 @@ export async function app(telemetryClient: TelemetryClient) {
 
   // TODO: https://github.com/waku-org/js-waku/issues/2079
   // Dialing bootstrap peers right on start in order to have Filter subscription initiated properly
-  await node.dial("/dns4/node-01.do-ams3.waku.test.status.im/tcp/8000/wss");
-  await node.dial(
-    "/dns4/node-01.ac-cn-hongkong-c.waku.test.status.im/tcp/8000/wss"
-  );
-  await node.dial(
-    "/dns4/node-01.gc-us-central1-a.waku.test.status.im/tcp/8000/wss"
-  );
-
+  // await node.dial("/dns4/node-01.do-ams3.waku.test.status.im/tcp/8000/wss");
+  // await node.dial("/dns4/node-01.ac-cn-hongkong-c.waku.test.status.im/tcp/8000/wss");
+  // await node.dial("/dns4/node-01.gc-us-central1-a.waku.test.status.im/tcp/8000/wss");
+  
   await waitForRemotePeer(node);
 
   const peerId = node.libp2p.peerId.toString();
@@ -121,7 +119,6 @@ export async function app(telemetryClient: TelemetryClient) {
               peerIdRemote: failure.peerId?.toString(),
               errorMessage: failure.error.toString(),
               contentTopic: DEFAULT_CONTENT_TOPIC,
-              pubsubTopic: DefaultPubsubTopic,
             }))
           );
         }

--- a/examples/dogfooding/src/index.ts
+++ b/examples/dogfooding/src/index.ts
@@ -43,12 +43,6 @@ export async function app(telemetryClient: TelemetryClient) {
   const node = await wakuNode();
   await node.start();
 
-  // TODO: https://github.com/waku-org/js-waku/issues/2079
-  // Dialing bootstrap peers right on start in order to have Filter subscription initiated properly
-  // await node.dial("/dns4/node-01.do-ams3.waku.test.status.im/tcp/8000/wss");
-  // await node.dial("/dns4/node-01.ac-cn-hongkong-c.waku.test.status.im/tcp/8000/wss");
-  // await node.dial("/dns4/node-01.gc-us-central1-a.waku.test.status.im/tcp/8000/wss");
-  
   await waitForRemotePeer(node);
 
   const peerId = node.libp2p.peerId.toString();


### PR DESCRIPTION
This PR updates `@waku/sdk` dependency.

On a bright side it seems size is decreased: 927 KiB -> 774 KiB.